### PR TITLE
Less access to protected members

### DIFF
--- a/photon_stream/Event.py
+++ b/photon_stream/Event.py
@@ -1,12 +1,13 @@
+import datetime as dt
 from .Geometry import Geometry
 import numpy as np
 import matplotlib.pyplot as plt
 from mpl_toolkits.mplot3d import Axes3D
+from .PhotonStream import PhotonStream
 from .plot import add_event_2_ax
 
-
 class Event(object):
-    def __init__(self): 
+    def __init__(self):
         self.geometry = None
         self.trigger_type = None
         self.photon_stream = None
@@ -17,6 +18,26 @@ class Event(object):
         self.time = None
         self.amplitude_saturated_pixels = None
 
+    @classmethod
+    def from_event_dict_and_run(cls, event_dict, run):
+        event = cls()
+
+        event.trigger_type = event_dict['TriggerType']
+        event.zd = event_dict['ZdPointing']
+        event.az = event_dict['AzPointing']
+        event.id = event_dict['EventNum']
+        event._time_unix_s = event_dict['UnixTimeUTC'][0]
+        event._time_unix_us = event_dict['UnixTimeUTC'][1]
+        event.amplitude_saturated_pixels = event_dict['SaturatedPixels']
+        event.time = dt.datetime.utcfromtimestamp(
+            event._time_unix_s + event._time_unix_us / 1e6)
+
+        event.run = run
+        event.geometry = run.geometry
+
+        event.photon_stream = PhotonStream.from_event_dict(event_dict)
+        return event
+
     def flatten_photon_stream(self, start_time=15e-9, end_time=65e-9):
         xyt = []
         for px, pixel_photons in enumerate(self.photon_stream.time_lines):
@@ -26,9 +47,9 @@ class Event(object):
                         self.geometry.pixel_zenith[px],
                         photon_slice*self.photon_stream.slice_duration
                         ]))
-        xyt = np.array(xyt) 
-        past_start = xyt[:,2] >= start_time
-        before_end = xyt[:,2] <= end_time
+        xyt = np.array(xyt)
+        past_start = xyt[:, 2] >= start_time
+        before_end = xyt[:, 2] <= end_time
         return xyt[past_start*before_end]
 
     def plot(self, mask=None):

--- a/photon_stream/PhotonStream.py
+++ b/photon_stream/PhotonStream.py
@@ -5,6 +5,13 @@ class PhotonStream(object):
         self.slice_duration = 0.0
         self.time_lines = []
 
+    @classmethod
+    def from_event_dict(cls, event_dict):
+        ps = cls()
+        ps.slice_duration = 0.5e-9
+        ps.time_lines = event_dict['PhotonArrivals']
+        return ps
+
     def _number_photons(self):
         number_photons = 0
         for time_line in self.time_lines:
@@ -23,15 +30,15 @@ class PhotonStream(object):
                 if min_slice_on_current_time_line < min_slice:
                     min_slice = min_slice_on_current_time_line
 
-        return min_slice, max_slice      
+        return min_slice, max_slice
 
     def truncate_time_lines(self, start_time, end_time):
         trunc_ps = PhotonStream()
         trunc_ps.slice_duration = self.slice_duration
         trunc_ps.time_lines = truncate_time_lines(
-            time_lines=self.time_lines, 
-            slice_duration=self.slice_duration, 
-            start_time=start_time, 
+            time_lines=self.time_lines,
+            slice_duration=self.slice_duration,
+            start_time=start_time,
             end_time=end_time)
         return trunc_ps
 
@@ -51,6 +58,6 @@ def truncate_time_lines(time_lines, slice_duration, start_time, end_time):
             arrival_time = arrival_slice*slice_duration
             if arrival_time >= start_time and arrival_time < end_time:
                 trunc_time_line.append(arrival_slice)
-        trunc_time_lines.append(trunc_time_line)       
+        trunc_time_lines.append(trunc_time_line)
 
     return trunc_time_lines

--- a/photon_stream/Run.py
+++ b/photon_stream/Run.py
@@ -1,8 +1,6 @@
 from .Geometry import Geometry
 from .Event import Event
 from .JsonLinesGzipReader import JsonLinesGzipReader
-from .PhotonStream import PhotonStream
-import datetime as dt
 
 
 class Run(object):
@@ -24,35 +22,13 @@ class Run(object):
         else:
             event_dict = self.reader.__next__()
             self._event_iterator += 1
-            return self._event_dict2event(event_dict)
-
-    def _event_dict2event(self, event_dict):
-        event = Event()
-        event.geometry = self.geometry
-
-        event.trigger_type = event_dict['TriggerType']
-        event.zd = event_dict['ZdPointing']
-        event.az = event_dict['AzPointing']
-        event.id = event_dict['EventNum']
-        event._time_unix_s = event_dict['UnixTimeUTC'][0]
-        event._time_unix_us = event_dict['UnixTimeUTC'][1]
-        event.run = self
-        event.amplitude_saturated_pixels = event_dict['SaturatedPixels']
-
-        ps = PhotonStream()
-        ps.slice_duration = 0.5e-9
-        ps.time_lines = event_dict['PhotonArrivals']
-        event.photon_stream = ps
-
-        event.time = dt.datetime.utcfromtimestamp(
-            event._time_unix_s+event._time_unix_us/1e6)
-        return event
+            return Event.from_event_dict_and_run(event_dict, self)
 
     def _read_first_event_to_learn_about_run(self):
         first_event_dict = self.reader.__next__()
         self.id = first_event_dict['RUNID']
         self.night = first_event_dict['NIGHT']
-        self._first_event = self._event_dict2event(first_event_dict)
+        self._first_event = Event.from_event_dict_and_run(first_event_dict, self)
 
     def __repr__(self):
         out = 'Run('


### PR DESCRIPTION
move construction of Event and PhotonStream out of Run, into their own class methods.

remove `_read_first_event_to_learn_about_run` and integrate into `__init__`