### PR TITLE
Binary io speed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
 before_install:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
+  - pip install pytest-benchmark
 install:
 - pip install .
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ before_install:
 install:
 - pip install .
 script:
-- py.test -k-nottravis
+- py.test -k-slow

--- a/photon_stream/experimental/_input_output.py
+++ b/photon_stream/experimental/_input_output.py
@@ -20,7 +20,7 @@ def append_photonstream_to_file(phs, fout):
 
     # WRITE PHOTON ARRIVAL SLICES
     raw_time_lines = np.zeros(
-        number_of_pixels_and_photons, 
+        number_of_pixels_and_photons,
         dtype=np.uint8)
     pos = 0
     for time_line in phs.time_lines:
@@ -52,18 +52,11 @@ def read_photonstream_from_file(fin):
         fin.read(number_of_pixels_and_photons),
         dtype=np.uint8)
 
-    phs.time_lines = []
-    if len(raw_time_lines) > 0:
-        phs.time_lines.append(array('B'))
-
-    pixel = 0
-    for i, symbol in enumerate(raw_time_lines):
-        if symbol == linebreak:
-            pixel += 1
-            if i+1 < len(raw_time_lines):
-                phs.time_lines.append(array('B'))
-        else:
-            phs.time_lines[pixel].append(symbol)
+    where = np.where(raw_time_lines == linebreak)[0][:-1] + 1
+    phs.time_lines = [
+        array('B', part[:-1])
+        for part in np.split(raw_time_lines, where)
+    ]
     return phs
 
 
@@ -133,7 +126,7 @@ def read_event_from_file(fin):
         event.observation_info = obs
         event.zd = pointing[0]
         event.az = pointing[1]
-        event.photon_stream = read_photonstream_from_file(fin)  
+        event.photon_stream = read_photonstream_from_file(fin)
         event.photon_stream.saturated_pixels = read_saturated_pixels_from_file(fin)
 
         return event

--- a/photon_stream/experimental/_input_output.py
+++ b/photon_stream/experimental/_input_output.py
@@ -54,7 +54,7 @@ def read_photonstream_from_file(fin):
 
     where = np.where(raw_time_lines == linebreak)[0][:-1] + 1
     phs.time_lines = [
-        array('B', part[:-1])
+        part[:-1]
         for part in np.split(raw_time_lines, where)
     ]
     return phs

--- a/photon_stream/experimental/_input_output.py
+++ b/photon_stream/experimental/_input_output.py
@@ -2,12 +2,12 @@ import numpy as np
 from ..PhotonStream import PhotonStream
 from ..Event import Event
 from ..ObservationInformation import ObservationInformation
-from array import array
 import datetime as dt
 import os
 import gzip
 
 linebreak = np.array([np.iinfo(np.uint8).max], dtype=np.uint8)
+
 
 def append_photonstream_to_file(phs, fout):
 
@@ -127,7 +127,8 @@ def read_event_from_file(fin):
         event.zd = pointing[0]
         event.az = pointing[1]
         event.photon_stream = read_photonstream_from_file(fin)
-        event.photon_stream.saturated_pixels = read_saturated_pixels_from_file(fin)
+        event.photon_stream.saturated_pixels = (
+            read_saturated_pixels_from_file(fin))
 
         return event
     except:

--- a/photon_stream/tests/test_binary_io.py
+++ b/photon_stream/tests/test_binary_io.py
@@ -93,3 +93,15 @@ def test_benchmark_binary_io(benchmark):
         for evt in ps.experimental.io.Run(run_path):
             pass
 
+
+def test_benchmark_json_io(benchmark):
+
+    run_path = pkg_resources.resource_filename(
+        'photon_stream',
+        'tests/resources/20170119_229_pass4_100events.phs.jsonl.gz')
+
+    @benchmark
+    def foo():
+        for evt in ps.EventListReader(run_path):
+            pass
+

--- a/photon_stream/tests/test_binary_io.py
+++ b/photon_stream/tests/test_binary_io.py
@@ -80,3 +80,16 @@ def test_jsonl2binary():
         evt_in = run_in[i]
         evt_ba = run_back[i]
         assert evt_in == evt_ba
+
+
+def test_benchmark_binary_io(benchmark):
+
+    run_path = pkg_resources.resource_filename(
+        'photon_stream',
+        'tests/resources/20170119_229_pass4_100events.phs.bin.gz')
+
+    @benchmark
+    def foo():
+        for evt in ps.experimental.io.Run(run_path):
+            pass
+

--- a/photon_stream/tests/test_muon_detection.py
+++ b/photon_stream/tests/test_muon_detection.py
@@ -3,46 +3,48 @@ import photon_stream as ps
 import tempfile
 import os
 import pkg_resources
+import pytest
 
 
 def test_ring_overlapp():
     overlapp = ps.muons.tools.circle_overlapp(
-        cx1=0.0, cy1=0.0, r1=1.0, 
+        cx1=0.0, cy1=0.0, r1=1.0,
         cx2=0.0, cy2=2.0, r2=1.0)
     assert overlapp == 0.0
 
     overlapp = ps.muons.tools.circle_overlapp(
-        cx1=0.0, cy1=0.0, r1=2.0, 
+        cx1=0.0, cy1=0.0, r1=2.0,
         cx2=0.0, cy2=0.0, r2=1.0)
     assert overlapp == 1.0
 
     overlapp = ps.muons.tools.circle_overlapp(
-        cx1=0.0, cy1=0.0, r1=100.0, 
+        cx1=0.0, cy1=0.0, r1=100.0,
         cx2=0.0, cy2=100.0, r2=1.0)
     assert np.abs(overlapp - 0.5) < 2e-3
 
     overlapp = ps.muons.tools.circle_overlapp(
-        cx1=0.0, cy1=0.0, r1=100.0, 
+        cx1=0.0, cy1=0.0, r1=100.0,
         cx2=0.0, cy2=99.0, r2=1.0)
-    assert overlapp == 1.0 
+    assert overlapp == 1.0
 
     overlapp = ps.muons.tools.circle_overlapp(
-        cx1=0.0, cy1=0.0, r1=100.0, 
+        cx1=0.0, cy1=0.0, r1=100.0,
         cx2=0.0, cy2=101.0, r2=1.0)
-    assert overlapp == 0.0 
+    assert overlapp == 0.0
 
 
+@pytest.mark.slow
 def test_muon_detection():
 
     np.random.seed(seed=1)
 
     muon_truth_path = pkg_resources.resource_filename(
-        'photon_stream', 
+        'photon_stream',
         'tests/resources/muon_sample_20140101_104.csv')
     muon_truth = np.genfromtxt(muon_truth_path)
 
     muon_sample_path = pkg_resources.resource_filename(
-        'photon_stream', 
+        'photon_stream',
         'tests/resources/20140101_104_muon_sample.phs.jsonl.gz')
 
     run = ps.EventListReader(muon_sample_path)
@@ -58,7 +60,7 @@ def test_muon_detection():
     for event in run:
         clusters = ps.PhotonStreamCluster(event.photon_stream)
         ret = ps.muons.detection(event, clusters)
-        
+
         if ret['is_muon']:
             if event.observation_info.event in muon_truth:
                 true_positives += 1
@@ -72,7 +74,7 @@ def test_muon_detection():
 
     precision = true_positives / (true_positives + false_positives)
     sensitivity = true_positives / (true_positives + false_negatives)
-    
+
     print('precision', precision)
     print('sensitivity', sensitivity)
 

--- a/photon_stream/tests/test_types.py
+++ b/photon_stream/tests/test_types.py
@@ -4,6 +4,7 @@ import datetime as dt
 import photon_stream as ps
 import pkg_resources
 import gzip
+import numpy as np
 
 
 def type_check(event):
@@ -17,14 +18,17 @@ def type_check(event):
     assert event.photon_stream.saturated_pixels.dtype == np.uint16
 
     for time_line in event.photon_stream.time_lines:
-        assert isinstance(time_line, array)
-        assert time_line.typecode == 'B'
+        assert isinstance(time_line, (np.ndarray, array))
+        if isinstance(time_line, np.ndarray):
+            assert time_line.dtype == np.uint8
+        else:
+            assert time_line.typecode == 'B'
 
     if hasattr(event, 'observation_info'):
         assert isinstance(event.observation_info.night, np.uint32)
         assert isinstance(event.observation_info.run, np.uint32)
         assert isinstance(event.observation_info.event, np.uint32)
-        
+
         assert isinstance(event.observation_info._time_unix_s, np.uint32)
         assert isinstance(event.observation_info._time_unix_us, np.uint32)
         assert isinstance(event.observation_info.time, dt.datetime)
@@ -46,16 +50,16 @@ def type_check(event):
 
 def test_types_from_json():
     run_path = pkg_resources.resource_filename(
-        'photon_stream', 
+        'photon_stream',
         'tests/resources/20170119_229_pass4_100events.phs.jsonl.gz')
     run = ps.EventListReader(run_path)
     event = next(run)
     type_check(event)
-    
+
 
 def test_types_from_binary():
     run_path = pkg_resources.resource_filename(
-        'photon_stream', 
+        'photon_stream',
         'tests/resources/20170119_229_pass4_100events.phs.bin.gz')
     with gzip.open(run_path, 'rb') as f:
         event = ps.experimental.io.read_event_from_file(f)


### PR DESCRIPTION
I was playing a bit with the speed of the `experimental.io.Run` speed. 

master: 733 +- 3ms
this branch: 220 +- 2 ms

Do:

    pip install pytest-benchmark
    py.test -k-slow

To get a benchmark on binary reading speed on your machine in < 20sec. 
Note the `-k-slow` parameter for pytest, the muon test takes ~80 seconds is skipped like this


