### PR TITLE
Split off plotting

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,13 @@ pip install git+https://github.com/fact-project/photon_stream
 ## Usage
 ```python
 import photon_stream as ps
+from photon_stream import plot as ps_plot
 import matplotlib.pyplot as plt
 
 reader = ps.EventListReader('20151001_011.phs.jsonl.gz')
 event = next(reader)
 
-ps.plot.event(event)
+ps_plot.event(event)
 plt.show()
 ```
 Read in the full CORSIKA simulation truth and estimate instrument response functions:

--- a/photon_stream/__init__.py
+++ b/photon_stream/__init__.py
@@ -11,7 +11,6 @@ from .jsonl2binary import jsonl2binary
 
 from . import production
 from . import muons
-from . import plot
 from . import io
 from . import simulation_truth
 from . import finger_histogram

--- a/photon_stream/tests/test_plotting_api.py
+++ b/photon_stream/tests/test_plotting_api.py
@@ -1,5 +1,6 @@
 import pytest
 import photon_stream as ps
+from photon_stream import plot as ps_plot
 import pkg_resources
 import tempfile
 import os
@@ -19,7 +20,7 @@ def test_event_can_plot_itself():
     )
 
     event = next(ps.EventListReader(run_path))
-    ps.plot.event(event)
+    ps_plot.event(event)
 
 
 @pytest.mark.slow
@@ -38,7 +39,7 @@ def test_event_can_be_converted_into_a_video():
     event = next(ps.EventListReader(run_path))
 
     with tempfile.NamedTemporaryFile(suffix='.mp4') as fname:
-        ps.plot.save_video(event, fname.name, steps=1)
+        ps_plot.save_video(event, fname.name, steps=1)
 
         assert os.path.isfile(fname.name)
         assert os.path.getsize(fname.name) > 0


### PR DESCRIPTION
Fix issue #9. Not all machines support plotting. So separate plotting from photon-stream processing