### PR TITLE
Fix lock file assertion

### DIFF
--- a/photon_stream/production/backup_main.py
+++ b/photon_stream/production/backup_main.py
@@ -45,9 +45,6 @@ def backup():
         'relleums',
         '.phs.isdc.backup.to.ethz.lock'
     )
-    if not os.path.exists(rsync_lock_path):
-        with open(rsync_lock_path, 'a') as out:
-            os.utime(rsync_lock_path)
     try:
         rsync_lock = FileLock(rsync_lock_path)
         with rsync_lock.acquire(timeout=3600):

--- a/photon_stream/production/isdc/_status.py
+++ b/photon_stream/production/isdc/_status.py
@@ -34,12 +34,7 @@ def status(
     tmp_status_dir = join(obs_dir, '.tmp_status')
     obs_std_dir = obs_dir+'.std'
 
-    all_paths_in_obs_dir = glob(join(obs_dir, '*'))
-    all_paths_in_obs_dir += glob(join(obs_dir, '.*'))
-    print(all_paths_in_obs_dir)
-
     assert exists(runstatus_path)
-    assert exists(runstatus_lock_path)
     os.makedirs(tmp_status_dir, exist_ok=True)
 
     try:

--- a/photon_stream/production/isdc/_status.py
+++ b/photon_stream/production/isdc/_status.py
@@ -34,6 +34,10 @@ def status(
     tmp_status_dir = join(obs_dir, '.tmp_status')
     obs_std_dir = obs_dir+'.std'
 
+    all_paths_in_obs_dir = glob(join(obs_dir, '*'))
+    all_paths_in_obs_dir += glob(join(obs_dir, '.*'))
+    print(all_paths_in_obs_dir)
+
     assert exists(runstatus_path)
     assert exists(runstatus_lock_path)
     os.makedirs(tmp_status_dir, exist_ok=True)

--- a/photon_stream/production/runstatus.py
+++ b/photon_stream/production/runstatus.py
@@ -10,7 +10,6 @@ import filelock
 
 from . import runinfo as ri
 from .runinfo import ID_RUNINFO_KEYS
-from . import tools
 from .runinfo2runstatus import runinfo2runstatus
 
 
@@ -31,7 +30,6 @@ def init(obs_dir, latest_runstatus=None):
         if latest_runstatus is None:
             latest_runstatus = _download_latest()
         ri.write(latest_runstatus, runstatus_path)
-    tools.touch(runstatus_lock_path)
 
 
 def update_to_latest(obs_dir, latest_runstatus=None, lock_timeout=1):

--- a/photon_stream/production/tools.py
+++ b/photon_stream/production/tools.py
@@ -10,11 +10,6 @@ import numpy as np
 import json
 
 
-def touch(path):
-    with open(path, 'a') as out:
-        os.utime(path)
-
-
 def number_of_events_in_file(path):
     reader = EventListReader(path)
     number_of_events = 0

--- a/photon_stream/tests/test_production.py
+++ b/photon_stream/tests/test_production.py
@@ -69,7 +69,6 @@ def run_production_scenario(out_dir):
     assert exists(phs_dir)
     assert exists(join(phs_dir, 'obs'))
     assert exists(join(phs_dir, 'obs', 'runstatus.csv'))
-    assert exists(join(phs_dir, 'obs', '.lock.runstatus.csv'))
 
     ps.production.isdc.status(
         obs_dir=obs_dir,


### PR DESCRIPTION
A change in the API of filelock made our unit-tests fail.

From now on use lock files the way they are meant to be used, see https://github.com/benediktschmitt/py-filelock. 

- Do not create (touch) them manually
- Do not assert their existence manually.

Fix issue #66